### PR TITLE
Add blockchain tracking skeleton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY target/wallet-0.0.1-SNAPSHOT.jar app.jar
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Wallet Tracking Service
+
+Este projeto demonstra um microservi\u00e7o simples em Spring Boot WebFlux para acompanhamento de transa\u00e7\u00f5es em diferentes redes blockchain.
+
+## Desenvolvimento
+
+```bash
+./mvnw spring-boot:run
+```
+
+### Docker
+
+```bash
+docker-compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  wallet:
+    build: .
+    ports:
+      - "8080:8080"

--- a/src/main/java/dev/bloco/wallet/config/BlockchainNetworkConfig.java
+++ b/src/main/java/dev/bloco/wallet/config/BlockchainNetworkConfig.java
@@ -1,0 +1,22 @@
+package dev.bloco.wallet.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "networks")
+public class BlockchainNetworkConfig {
+
+    private Map<String, List<String>> endpoints;
+
+    public Map<String, List<String>> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(Map<String, List<String>> endpoints) {
+        this.endpoints = endpoints;
+    }
+}

--- a/src/main/java/dev/bloco/wallet/config/WebFluxConfig.java
+++ b/src/main/java/dev/bloco/wallet/config/WebFluxConfig.java
@@ -1,0 +1,17 @@
+package dev.bloco.wallet.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.config.CorsRegistry;
+
+@Configuration
+@EnableWebFlux
+public class WebFluxConfig implements WebFluxConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*");
+    }
+}

--- a/src/main/java/dev/bloco/wallet/config/WebSocketConfig.java
+++ b/src/main/java/dev/bloco/wallet/config/WebSocketConfig.java
@@ -1,0 +1,16 @@
+package dev.bloco.wallet.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+import org.springframework.context.annotation.Bean;
+
+@Configuration
+@EnableWebFlux
+public class WebSocketConfig {
+
+    @Bean
+    public WebSocketHandlerAdapter handlerAdapter() {
+        return new WebSocketHandlerAdapter();
+    }
+}

--- a/src/main/java/dev/bloco/wallet/handler/TrackingController.java
+++ b/src/main/java/dev/bloco/wallet/handler/TrackingController.java
@@ -1,0 +1,26 @@
+package dev.bloco.wallet.handler;
+
+import dev.bloco.wallet.model.Transaction;
+import dev.bloco.wallet.model.TrackingRequest;
+import dev.bloco.wallet.service.TransactionTrackingService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/tracking")
+public class TrackingController {
+
+    private final TransactionTrackingService trackingService;
+
+    public TrackingController(TransactionTrackingService trackingService) {
+        this.trackingService = trackingService;
+    }
+
+    @PostMapping("/transactions")
+    public Flux<Transaction> track(@RequestBody TrackingRequest request) {
+        return trackingService.track(request);
+    }
+}

--- a/src/main/java/dev/bloco/wallet/handler/TrackingWebSocketHandler.java
+++ b/src/main/java/dev/bloco/wallet/handler/TrackingWebSocketHandler.java
@@ -1,0 +1,28 @@
+package dev.bloco.wallet.handler;
+
+import dev.bloco.wallet.model.TrackingRequest;
+import dev.bloco.wallet.service.TransactionTrackingService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TrackingWebSocketHandler implements WebSocketHandler {
+
+    private final TransactionTrackingService trackingService;
+
+    public TrackingWebSocketHandler(TransactionTrackingService trackingService) {
+        this.trackingService = trackingService;
+    }
+
+    @Override
+    public Mono<Void> handle(WebSocketSession session) {
+        return session.receive()
+                .map(msg -> msg.getPayloadAsText())
+                .map(json -> new TrackingRequest("address", json, java.util.List.of()))
+                .flatMapMany(trackingService::track)
+                .map(tx -> session.textMessage(tx.hash()))
+                .as(session::send);
+    }
+}

--- a/src/main/java/dev/bloco/wallet/model/Block.java
+++ b/src/main/java/dev/bloco/wallet/model/Block.java
@@ -1,0 +1,9 @@
+package dev.bloco.wallet.model;
+
+import java.time.Instant;
+import java.util.List;
+
+public record Block(long number,
+                    Instant timestamp,
+                    List<Transaction> transactions) {
+}

--- a/src/main/java/dev/bloco/wallet/model/BridgeEvent.java
+++ b/src/main/java/dev/bloco/wallet/model/BridgeEvent.java
@@ -1,0 +1,10 @@
+package dev.bloco.wallet.model;
+
+import java.time.Instant;
+
+public record BridgeEvent(String sourceNetwork,
+                          String targetNetwork,
+                          String bridgeContract,
+                          String hash,
+                          Instant timestamp) {
+}

--- a/src/main/java/dev/bloco/wallet/model/TrackingRequest.java
+++ b/src/main/java/dev/bloco/wallet/model/TrackingRequest.java
@@ -1,0 +1,8 @@
+package dev.bloco.wallet.model;
+
+import java.util.List;
+
+public record TrackingRequest(String type,
+                              String value,
+                              List<String> networks) {
+}

--- a/src/main/java/dev/bloco/wallet/model/Transaction.java
+++ b/src/main/java/dev/bloco/wallet/model/Transaction.java
@@ -1,0 +1,11 @@
+package dev.bloco.wallet.model;
+
+import java.time.Instant;
+
+public record Transaction(String hash,
+                          String from,
+                          String to,
+                          String network,
+                          Instant timestamp,
+                          boolean confirmed) {
+}

--- a/src/main/java/dev/bloco/wallet/repository/TransactionRepository.java
+++ b/src/main/java/dev/bloco/wallet/repository/TransactionRepository.java
@@ -1,0 +1,9 @@
+package dev.bloco.wallet.repository;
+
+import dev.bloco.wallet.model.Transaction;
+import reactor.core.publisher.Flux;
+
+public interface TransactionRepository {
+
+    Flux<Transaction> saveAll(Flux<Transaction> transactions);
+}

--- a/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
+++ b/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
@@ -1,0 +1,20 @@
+package dev.bloco.wallet.service;
+
+import dev.bloco.wallet.model.Block;
+import dev.bloco.wallet.model.Transaction;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+public class BlockchainConsumerService {
+
+    // TODO: implement websocket connections to blockchain nodes
+    public Flux<Block> streamBlocks(String network) {
+        return Flux.empty();
+    }
+
+    public Flux<Transaction> streamTransactions(String network) {
+        return streamBlocks(network)
+                .flatMap(block -> Flux.fromIterable(block.transactions()));
+    }
+}

--- a/src/main/java/dev/bloco/wallet/service/BloomFilterService.java
+++ b/src/main/java/dev/bloco/wallet/service/BloomFilterService.java
@@ -1,0 +1,20 @@
+package dev.bloco.wallet.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Service
+public class BloomFilterService {
+
+    private final ConcurrentMap<String, Boolean> dummyFilter = new ConcurrentHashMap<>();
+
+    public boolean mightContain(String network, String address) {
+        return dummyFilter.containsKey(network + address);
+    }
+
+    public void add(String network, String address) {
+        dummyFilter.put(network + address, Boolean.TRUE);
+    }
+}

--- a/src/main/java/dev/bloco/wallet/service/BridgeDetectionService.java
+++ b/src/main/java/dev/bloco/wallet/service/BridgeDetectionService.java
@@ -1,0 +1,15 @@
+package dev.bloco.wallet.service;
+
+import dev.bloco.wallet.model.BridgeEvent;
+import dev.bloco.wallet.model.Transaction;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+public class BridgeDetectionService {
+
+    public Flux<BridgeEvent> detect(Flux<Transaction> transactions) {
+        // TODO: implement bridge detection logic
+        return Flux.empty();
+    }
+}

--- a/src/main/java/dev/bloco/wallet/service/TransactionTrackingService.java
+++ b/src/main/java/dev/bloco/wallet/service/TransactionTrackingService.java
@@ -1,0 +1,26 @@
+package dev.bloco.wallet.service;
+
+import dev.bloco.wallet.model.Transaction;
+import dev.bloco.wallet.model.TrackingRequest;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+public class TransactionTrackingService {
+
+    private final BlockchainConsumerService blockchainConsumerService;
+    private final BloomFilterService bloomFilterService;
+
+    public TransactionTrackingService(BlockchainConsumerService blockchainConsumerService,
+                                      BloomFilterService bloomFilterService) {
+        this.blockchainConsumerService = blockchainConsumerService;
+        this.bloomFilterService = bloomFilterService;
+    }
+
+    public Flux<Transaction> track(TrackingRequest request) {
+        return Flux.fromIterable(request.networks())
+                .flatMap(network -> blockchainConsumerService.streamTransactions(network)
+                        .filter(tx -> tx.from().equalsIgnoreCase(request.value())
+                                || tx.to().equalsIgnoreCase(request.value())));
+    }
+}

--- a/src/main/java/dev/bloco/wallet/util/BloomFilterUtil.java
+++ b/src/main/java/dev/bloco/wallet/util/BloomFilterUtil.java
@@ -1,0 +1,13 @@
+package dev.bloco.wallet.util;
+
+public class BloomFilterUtil {
+
+    private BloomFilterUtil() {
+    }
+
+    public static int hash(String value, int seed) {
+        int h = value.hashCode() ^ seed;
+        h ^= (h >>> 20) ^ (h >>> 12);
+        return h ^ (h >>> 7) ^ (h >>> 4);
+    }
+}

--- a/src/main/java/dev/bloco/wallet/util/NetworkUtils.java
+++ b/src/main/java/dev/bloco/wallet/util/NetworkUtils.java
@@ -1,0 +1,14 @@
+package dev.bloco.wallet.util;
+
+import java.time.Duration;
+
+public class NetworkUtils {
+
+    private NetworkUtils() {
+    }
+
+    public static Duration reconnectBackoff(int attempts) {
+        long seconds = Math.min(60, (long) Math.pow(2, attempts));
+        return Duration.ofSeconds(seconds);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=wallet
+
+# Network endpoints example
+networks.endpoints.ethereum[0]=wss://ethereum.example
+networks.endpoints.polygon[0]=wss://polygon.example

--- a/src/test/java/dev/bloco/wallet/service/BloomFilterServiceTest.java
+++ b/src/test/java/dev/bloco/wallet/service/BloomFilterServiceTest.java
@@ -1,0 +1,14 @@
+package dev.bloco.wallet.service;
+
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+class BloomFilterServiceTest {
+
+    @Test
+    void addAndCheck() {
+        BloomFilterService service = new BloomFilterService();
+        service.add("polygon", "0x1");
+        assert service.mightContain("polygon", "0x1");
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap WebFlux configuration
- add skeleton services and models for blockchain tracking
- implement simple REST and WebSocket handlers
- provide Dockerfile and compose setup
- include minimal tests and README

## Testing
- `./mvnw -q test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68682cc792448331b6e2a6b5d9c614bd