### PR TITLE
Fix compile error in websocket handler

### DIFF
--- a/src/main/java/dev/bloco/wallet/handler/TrackingWebSocketHandler.java
+++ b/src/main/java/dev/bloco/wallet/handler/TrackingWebSocketHandler.java
@@ -21,7 +21,7 @@ public class TrackingWebSocketHandler implements WebSocketHandler {
         return session.receive()
                 .map(msg -> msg.getPayloadAsText())
                 .map(json -> new TrackingRequest("address", json, java.util.List.of()))
-                .flatMapMany(trackingService::track)
+                .flatMap(trackingService::track)
                 .map(tx -> session.textMessage(tx.hash()))
                 .as(session::send);
     }


### PR DESCRIPTION
## Summary
- fix transaction streaming call inside `TrackingWebSocketHandler`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6868525a89f08331a78986e48570a8d0