### PR TITLE
Fix bean conflict by removing servlet websocket starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-websocket</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- remove the `spring-boot-starter-websocket` dependency so the application only uses WebFlux

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686855767ebc833196fa1703b380b352