### PR TITLE
Integrate web3j for live blockchain monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Este projeto demonstra um microservi\u00e7o simples em Spring Boot WebFlux para acompanhamento de transa\u00e7\u00f5es em diferentes redes blockchain.
 
+O servi\u00e7o utiliza a biblioteca **web3j 4.12** para se conectar \u00e0s redes e monitorar novos blocos e transa\u00e7\u00f5es.
+
 ## Desenvolvimento
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Web3j for blockchain connectivity -->
+        <dependency>
+            <groupId>org.web3j</groupId>
+            <artifactId>core</artifactId>
+            <version>4.12.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
+++ b/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
@@ -53,7 +53,15 @@ public class BlockchainConsumerService {
             if (endpoints == null || endpoints.isEmpty()) {
                 throw new IllegalArgumentException("No endpoints configured for network: " + n);
             }
-            return buildClient(endpoints.get(0));
+            for (String endpoint : endpoints) {
+                try {
+                    return buildClient(endpoint);
+                } catch (RuntimeException e) {
+                    // Log the failure and try the next endpoint
+                    System.err.println("Failed to connect to endpoint: " + endpoint + ". Trying next...");
+                }
+            }
+            throw new RuntimeException("Failed to connect to any endpoint for network: " + n);
         });
     }
 

--- a/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
+++ b/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
@@ -88,7 +88,7 @@ public class BlockchainConsumerService {
                     return Flux.from(flowable)
                             .map(ethBlock -> toBlock(network, ethBlock.getBlock()));
                 })
-                .retryWhen(Retry.backoff(Long.MAX_VALUE, NetworkUtils.reconnectBackoff(1)));
+                .retryWhen(Retry.backoff(10, NetworkUtils.reconnectBackoff(1)).maxBackoff(Duration.ofMinutes(5)));
     }
 
     public Flux<Transaction> streamTransactions(String network) {

--- a/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
+++ b/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
@@ -1,28 +1,86 @@
 package dev.bloco.wallet.service;
 
+import dev.bloco.wallet.config.BlockchainNetworkConfig;
 import dev.bloco.wallet.model.Block;
 import dev.bloco.wallet.model.Transaction;
+import dev.bloco.wallet.util.NetworkUtils;
+import io.reactivex.Flowable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.util.retry.Retry;
 
-import java.time.Duration;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.protocol.websocket.WebSocketClient;
+import org.web3j.protocol.websocket.WebSocketService;
+
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Service
 public class BlockchainConsumerService {
 
-    // Simple stub that emits dummy blocks every second
+    private final BlockchainNetworkConfig networkConfig;
+    private final Map<String, Web3j> clients = new ConcurrentHashMap<>();
+
+    public BlockchainConsumerService(BlockchainNetworkConfig networkConfig) {
+        this.networkConfig = networkConfig;
+    }
+
+    private Web3j buildClient(String endpoint) {
+        try {
+            if (endpoint.startsWith("ws")) {
+                WebSocketClient client = new WebSocketClient(new URI(endpoint));
+                WebSocketService service = new WebSocketService(client, false);
+                service.connect();
+                return Web3j.build(service);
+            }
+            return Web3j.build(new HttpService(endpoint));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to connect to " + endpoint, e);
+        }
+    }
+
+    private Web3j getWeb3j(String network) {
+        return clients.computeIfAbsent(network, n -> {
+            Map<String, List<String>> endpointsMap = networkConfig.getEndpoints();
+            List<String> endpoints = endpointsMap.get(n);
+            if (endpoints == null || endpoints.isEmpty()) {
+                throw new IllegalArgumentException("No endpoints configured for network: " + n);
+            }
+            return buildClient(endpoints.get(0));
+        });
+    }
+
+    private Block toBlock(String network, EthBlock.Block block) {
+        Instant timestamp = Instant.ofEpochSecond(block.getTimestamp().longValue());
+        List<Transaction> transactions = block.getTransactions().stream()
+                .map(txResult -> (EthBlock.TransactionObject) txResult.get())
+                .map(tx -> new Transaction(
+                        tx.getHash(),
+                        tx.getFrom(),
+                        tx.getTo(),
+                        network,
+                        timestamp,
+                        tx.getBlockHash() != null
+                ))
+                .collect(Collectors.toList());
+        return new Block(block.getNumber().longValue(), timestamp, transactions);
+    }
+
     public Flux<Block> streamBlocks(String network) {
-        return Flux.interval(Duration.ofSeconds(1))
-                .map(i -> {
-                    Instant now = Instant.now();
-                    Transaction tx = new Transaction(
-                            "tx-" + network + "-" + i,
-                            "0xfrom", "0xto", network,
-                            now, true);
-                    return new Block(i, now, List.of(tx));
-                });
+        return Flux.defer(() -> {
+                    Web3j web3j = getWeb3j(network);
+                    Flowable<EthBlock> flowable = web3j.blockFlowable(true);
+                    return Flux.from(flowable)
+                            .map(ethBlock -> toBlock(network, ethBlock.getBlock()));
+                })
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, NetworkUtils.reconnectBackoff(1)));
     }
 
     public Flux<Transaction> streamTransactions(String network) {


### PR DESCRIPTION
## Summary
- add web3j dependency
- use web3j to stream blocks and transactions
- mention web3j usage in README

## Testing
- `./mvnw test -DskipTests=false -DfailIfNoTests=false`

------
https://chatgpt.com/codex/tasks/task_e_6868964f23a08331b01db4810c41776f