### PR TITLE
Add integration tests for multiple blockchain providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     </scm>
     <properties>
         <java.version>21</java.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
     </properties>
     <dependencies>
         <dependency>
@@ -56,6 +57,38 @@
             <groupId>org.web3j</groupId>
             <artifactId>core</artifactId>
             <version>4.12.0</version>
+        </dependency>
+
+        <!-- Resilience and monitoring -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-reactor</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+        <!-- Bloom filter support -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.1.0-jre</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
+++ b/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
@@ -75,7 +75,7 @@ public class BlockchainMonitorService {
     }
 
     public boolean isMonitoredAddress(String address) {
-        return addressBloom.mightContain(address);
+        return addresses.contains(address);
     }
 
     public void addEventTopic(String topic) {

--- a/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
+++ b/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
@@ -149,7 +149,7 @@ public class BlockchainMonitorService {
             lastBlocks.put(httpUrl, latest);
             EthFilter filter = new EthFilter(new DefaultBlockParameterNumber(start),
                     new DefaultBlockParameterNumber(latest), List.copyOf(addresses));
-            topics.forEach(filter::addOptionalTopics);
+            filter.addOptionalTopics(List.copyOf(topics));
             return Mono.fromFuture(client.ethGetLogs(filter).sendAsync()).map(EthLog::getLogs);
         });
     }

--- a/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
+++ b/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
@@ -89,7 +89,7 @@ public class BlockchainMonitorService {
     }
 
     public boolean isMonitoredTopic(String topic) {
-        return topicBloom.mightContain(topic);
+        return topics.contains(topic);
     }
 
     private void rebuildAddressBloom() {

--- a/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
+++ b/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
@@ -58,7 +58,7 @@ public class BlockchainMonitorService {
             try {
                 service.connect();
             } catch (Exception e) {
-                throw new RuntimeException("Failed to connect to websocket", e);
+                throw new RuntimeException("Failed to connect to websocket at " + u, e);
             }
             return Web3j.build(service);
         });

--- a/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
+++ b/src/main/java/dev/bloco/blockchain/BlockchainMonitorService.java
@@ -1,0 +1,165 @@
+package dev.bloco.blockchain;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.springframework.stereotype.Service;
+
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.reactivex.Flowable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.DefaultBlockParameterNumber;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthBlockNumber;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
+import org.web3j.protocol.core.methods.response.EthLog;
+import org.web3j.protocol.http.HttpService;
+import org.web3j.protocol.websocket.WebSocketService;
+
+/**
+ * Service capable of monitoring multiple blockchain operations concurrently. It
+ * allows registering and removing addresses and event topics on the fly without
+ * impacting ongoing monitoring.
+ */
+@Service
+public class BlockchainMonitorService {
+
+    private final ConcurrentMap<String, Web3j> httpClients = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Web3j> wsClients = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, BigInteger> lastBlocks = new ConcurrentHashMap<>();
+
+    private final Set<String> addresses = ConcurrentHashMap.newKeySet();
+    private final Set<String> topics = ConcurrentHashMap.newKeySet();
+    private volatile BloomFilter<String> addressBloom = BloomFilter.create(
+            Funnels.unencodedCharsFunnel(), 100);
+    private volatile BloomFilter<String> topicBloom = BloomFilter.create(
+            Funnels.unencodedCharsFunnel(), 100);
+
+    private Web3j httpClient(String url) {
+        return httpClients.computeIfAbsent(url, u -> Web3j.build(new HttpService(u)));
+    }
+
+    private Web3j wsClient(String url) {
+        return wsClients.computeIfAbsent(url, u -> {
+            WebSocketService service = new WebSocketService(u, true);
+            try {
+                service.connect();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to connect to websocket", e);
+            }
+            return Web3j.build(service);
+        });
+    }
+
+    public void addAddress(String address) {
+        addresses.add(address);
+        rebuildAddressBloom();
+    }
+
+    public void removeAddress(String address) {
+        addresses.remove(address);
+        rebuildAddressBloom();
+    }
+
+    public boolean isMonitoredAddress(String address) {
+        return addressBloom.mightContain(address);
+    }
+
+    public void addEventTopic(String topic) {
+        topics.add(topic);
+        rebuildTopicBloom();
+    }
+
+    public void removeEventTopic(String topic) {
+        topics.remove(topic);
+        rebuildTopicBloom();
+    }
+
+    public boolean isMonitoredTopic(String topic) {
+        return topicBloom.mightContain(topic);
+    }
+
+    private void rebuildAddressBloom() {
+        BloomFilter<String> filter = BloomFilter.create(Funnels.unencodedCharsFunnel(),
+                Math.max(addresses.size(), 1));
+        addresses.forEach(filter::put);
+        addressBloom = filter;
+    }
+
+    private void rebuildTopicBloom() {
+        BloomFilter<String> filter = BloomFilter.create(Funnels.unencodedCharsFunnel(),
+                Math.max(topics.size(), 1));
+        topics.forEach(filter::put);
+        topicBloom = filter;
+    }
+
+    @Retry(name = "web3")
+    @CircuitBreaker(name = "web3")
+    public Mono<BigInteger> latestBlockNumber(String httpUrl) {
+        return Mono.fromFuture(httpClient(httpUrl).ethBlockNumber().sendAsync())
+                .map(EthBlockNumber::getBlockNumber);
+    }
+
+    @Retry(name = "web3")
+    @CircuitBreaker(name = "web3")
+    public Mono<BigInteger> transactionCount(String httpUrl, String address) {
+        return Mono.fromFuture(httpClient(httpUrl)
+                .ethGetTransactionCount(address, DefaultBlockParameterName.LATEST).sendAsync())
+                .map(EthGetTransactionCount::getTransactionCount);
+    }
+
+    @Retry(name = "web3")
+    @CircuitBreaker(name = "web3")
+    public Flux<EthBlock> newBlocks(String wsUrl) {
+        return Flux.defer(() -> {
+            Flowable<EthBlock> flowable = wsClient(wsUrl).blockFlowable(true);
+            return Flux.from(flowable);
+        });
+    }
+
+    @Retry(name = "web3")
+    @CircuitBreaker(name = "web3")
+    public Flux<EthLog.LogResult> monitorLogs(String httpUrl) {
+        return Flux.interval(Duration.ofSeconds(5))
+                .flatMap(tick -> fetchLogs(httpUrl))
+                .flatMapIterable(list -> list)
+                .filter(this::matchesFilter)
+                .publish()
+                .refCount();
+    }
+
+    private Mono<List<EthLog.LogResult>> fetchLogs(String httpUrl) {
+        Web3j client = httpClient(httpUrl);
+        return Mono.fromFuture(client.ethBlockNumber().sendAsync()).flatMap(bn -> {
+            BigInteger latest = bn.getBlockNumber();
+            BigInteger start = lastBlocks.getOrDefault(httpUrl, latest);
+            lastBlocks.put(httpUrl, latest);
+            EthFilter filter = new EthFilter(new DefaultBlockParameterNumber(start),
+                    new DefaultBlockParameterNumber(latest), List.copyOf(addresses));
+            topics.forEach(filter::addOptionalTopics);
+            return Mono.fromFuture(client.ethGetLogs(filter).sendAsync()).map(EthLog::getLogs);
+        });
+    }
+
+    private boolean matchesFilter(EthLog.LogResult logResult) {
+        if (logResult instanceof EthLog.LogObject log) {
+            boolean addressMatch = addressBloom.mightContain(log.getAddress());
+            boolean topicMatch = log.getTopics().stream().anyMatch(topicBloom::mightContain);
+            return addressMatch && topicMatch;
+        }
+        return false;
+    }
+}

--- a/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
+++ b/src/main/java/dev/bloco/wallet/service/BlockchainConsumerService.java
@@ -16,6 +16,7 @@ import org.web3j.protocol.websocket.WebSocketClient;
 import org.web3j.protocol.websocket.WebSocketService;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.application.name=wallet
-
-# Network endpoints example
-networks.endpoints.ethereum[0]=wss://ethereum.example
-networks.endpoints.polygon[0]=wss://polygon.example

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: wallet
+
+networks:
+  endpoints:
+    ethereum: ${ETHEREUM_WS_URL:}
+    polygon: ${POLYGON_WS_URL:}
+
+resilience4j:
+  retry:
+    instances:
+      web3:
+        max-attempts: 3
+        wait-duration: 1s
+  circuitbreaker:
+    instances:
+      web3:
+        sliding-window-type: count_based
+        sliding-window-size: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 5s

--- a/src/test/java/dev/bloco/blockchain/Web3ProvidersIntegrationTest.java
+++ b/src/test/java/dev/bloco/blockchain/Web3ProvidersIntegrationTest.java
@@ -1,0 +1,127 @@
+package dev.bloco.blockchain;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.web3j.protocol.core.methods.response.EthBlock;
+import org.web3j.protocol.core.methods.response.EthLog;
+
+import reactor.test.StepVerifier;
+
+/**
+ * Integration tests that validate connectivity with different blockchain
+ * providers over HTTP polling and WebSocket pub/sub endpoints. Tests are
+ * skipped when the respective provider URL is not configured.
+ */
+public class Web3ProvidersIntegrationTest {
+
+    private static final String TEST_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    private static final String USDT_CONTRACT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+    private static final String TRANSFER_TOPIC =
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a6b7fa1c012";
+
+    private final BlockchainMonitorService service = new BlockchainMonitorService();
+
+    static Stream<Arguments> httpProviders() {
+        List<Arguments> providers = Stream.of(
+                provider("Infura", System.getenv("INFURA_HTTP_URL")),
+                provider("Alchemy", System.getenv("ALCHEMY_HTTP_URL")),
+                provider("AllNodes", System.getenv("ALLNODES_HTTP_URL")),
+                provider("Tenderly", System.getenv("TENDERLY_HTTP_URL")))
+                .filter(p -> p.url != null && !p.url.isBlank())
+                .map(p -> Arguments.of(p.name, p.url))
+                .toList();
+        return providers.isEmpty() ? Stream.of(Arguments.of("none", "")) : providers.stream();
+    }
+
+    static Stream<Arguments> wsProviders() {
+        List<Arguments> providers = Stream.of(
+                provider("Infura", System.getenv("INFURA_WS_URL")),
+                provider("Alchemy", System.getenv("ALCHEMY_WS_URL")),
+                provider("AllNodes", System.getenv("ALLNODES_WS_URL")),
+                provider("Tenderly", System.getenv("TENDERLY_WS_URL")))
+                .filter(p -> p.url != null && !p.url.isBlank())
+                .map(p -> Arguments.of(p.name, p.url))
+                .toList();
+        return providers.isEmpty() ? Stream.of(Arguments.of("none", "")) : providers.stream();
+    }
+
+    private static Provider provider(String name, String url) {
+        return new Provider(name, url);
+    }
+
+    private record Provider(String name, String url) {}
+
+    @ParameterizedTest(name = "{0} latest block")
+    @MethodSource("httpProviders")
+    void getLatestBlock(String name, String url) {
+        assumeTrue(url != null && !url.isBlank());
+        StepVerifier.create(service.latestBlockNumber(url))
+                .assertNext(block -> assertTrue(block.signum() > 0, name + " returned invalid block number"))
+                .verifyTimeout(Duration.ofSeconds(30));
+    }
+
+    @ParameterizedTest(name = "{0} transaction count")
+    @MethodSource("httpProviders")
+    void getTransactionCount(String name, String url) {
+        assumeTrue(url != null && !url.isBlank());
+        StepVerifier.create(service.transactionCount(url, TEST_ADDRESS))
+                .assertNext(count -> assertNotNull(count, name + " returned null transaction count"))
+                .verifyTimeout(Duration.ofSeconds(30));
+    }
+
+    @ParameterizedTest(name = "{0} recent logs")
+    @MethodSource("httpProviders")
+    void getRecentLogs(String name, String url) {
+        assumeTrue(url != null && !url.isBlank());
+        service.addAddress(USDT_CONTRACT);
+        service.addEventTopic(TRANSFER_TOPIC);
+        StepVerifier.create(service.monitorLogs(url).take(1))
+                .assertNext(log -> assertNotNull(log, name + " returned null logs"))
+                .verifyTimeout(Duration.ofSeconds(60));
+    }
+
+    @ParameterizedTest(name = "{0} websocket blocks")
+    @MethodSource("wsProviders")
+    void subscribeBlocks(String name, String url) {
+        assumeTrue(url != null && !url.isBlank());
+        StepVerifier.create(service.newBlocks(url).take(1))
+                .assertNext(block -> assertNotNull(block, name + " did not receive block"))
+                .verifyTimeout(Duration.ofSeconds(60));
+    }
+
+    @Test
+    void invalidEndpointEmitsError() {
+        StepVerifier.create(service.latestBlockNumber("http://127.0.0.1:1"))
+                .expectError()
+                .verify();
+    }
+
+    @Test
+    void addAndRemoveAddresses() {
+        service.addAddress("0x1");
+        service.addAddress("0x2");
+        assertTrue(service.isMonitoredAddress("0x1"));
+        service.removeAddress("0x1");
+        assertFalse(service.isMonitoredAddress("0x1"));
+        assertTrue(service.isMonitoredAddress("0x2"));
+    }
+
+    @Test
+    void addAndRemoveTopics() {
+        service.addEventTopic("0xabc");
+        service.addEventTopic("0xdef");
+        assertTrue(service.isMonitoredTopic("0xabc"));
+        service.removeEventTopic("0xabc");
+        assertFalse(service.isMonitoredTopic("0xabc"));
+        assertTrue(service.isMonitoredTopic("0xdef"));
+    }
+}


### PR DESCRIPTION
## Summary
- fix Web3j imports and log fetching in `BlockchainMonitorService`
- ensure `BlockchainConsumerService` builds with Duration-based retry backoff
- make provider integration tests resilient to missing endpoint configuration

## Testing
- `./mvnw -Djava.net.preferIPv4Stack=true test`


------
https://chatgpt.com/codex/tasks/task_e_689a8534098083318295cbd77b101a64